### PR TITLE
New F5 metrics, cluster support and looping/service support

### DIFF
--- a/graphitecollectors/f5.py
+++ b/graphitecollectors/f5.py
@@ -657,7 +657,7 @@ def gather_f5_metrics(ltm_host, user, password, prefix, remote_ts,
                 logging.debug("metric = %s" % str(metric))
                 metric_list.append(metric)
             logging.info("Retrieving member count for all pools...")
-            pool_members = b.LocalLB.Pool.get_all_member_statistics(pool_names=[pool_name])
+            pool_members = b.LocalLB.Pool.get_all_member_statistics(pool_names=[pool_list])
             pool_member_count = [len(x) for x in pool_members]
             for pool_name, stat_val in zip(pool_list, pool_member_count):
                 stat_path = cleanStatPath("%s.pool.%s.member_count" % (prefix, pool_name))
@@ -665,10 +665,10 @@ def gather_f5_metrics(ltm_host, user, password, prefix, remote_ts,
                 logging.debug("metric = %s" % str(metric))
                 metric_list.append(metric)
             if not no_pool_members:
-                for memindex, members in enumerate(pool_members):
+                for pool_name, members in zip(pool_list, pool_members):
                     for cur_member in members['statistics']:
                         member_name = "%s-%s" % (cur_member['member']['address'].split('/')[-1].lower().replace('.', '-'), cur_member['member']['port'])
-                        metric_path = cleanStatPath("%s.pool.%s.members.%s.%s" % (prefix, pool_name, memindex, member_name))
+                        metric_path = cleanStatPath("%s.pool.%s.members.%s" % (prefix, pool_name, member_name))
                         metrics = itterate_statistics(cur_member['statistics'], metric_path, now, POOL_MEMBER_STATISTICS)
                         metric_list.extend(metrics)
         else:

--- a/graphitecollectors/f5.py
+++ b/graphitecollectors/f5.py
@@ -667,7 +667,7 @@ def gather_f5_metrics(ltm_host, user, password, prefix, remote_ts,
             if not no_pool_members:
                 for memindex, members in enumerate(pool_members):
                     for cur_member in members['statistics']:
-                        member_name = "%s-%s" % (cur_member['member']['address'].split('/')[-1].lower(), cur_member['member']['port'])
+                        member_name = "%s-%s" % (cur_member['member']['address'].split('/')[-1].lower().replace('.', '-'), cur_member['member']['port'])
                         metric_path = cleanStatPath("%s.pool.%s.members.%s.%s" % (prefix, pool_name, memindex, member_name))
                         metrics = itterate_statistics(cur_member['statistics'], metric_path, now, POOL_MEMBER_STATISTICS)
                         metric_list.extend(metrics)

--- a/graphitecollectors/f5.py
+++ b/graphitecollectors/f5.py
@@ -838,7 +838,7 @@ def main():
                 logging.info("Sleeping for %d seconds" % sleepDuration)
                 time.sleep(sleepDuration)
             else:
-                logging.info("Sleep < 0 for loop of %d seconds - Not Sleeping", % args.loopInterval)
+                logging.info("Sleep < 0 for loop of %d seconds - Not Sleeping" % args.loopInterval)
         else:
             running = False
 


### PR DESCRIPTION
The changes here add the ability for the f5 collector to run as a service in a loop given a set time interval.  This drastically reduces system load and makes the metric collection timing more consistent.

This also adds the ability to only collect certain metrics from the active node in a cluster vs collecting all metrics all the time.

Also added code to dig into a pools members and send in metrics for those (e.g. current sessions/connections) etc.

Additionally, stat recursion logic has been moved into a function, names are now "cleaned" (forward slashes and double .'s removed).
